### PR TITLE
made terraformer able to run on non-AR world

### DIFF
--- a/src/main/java/zmaster587/advancedRocketry/api/dimension/IDimensionProperties.java
+++ b/src/main/java/zmaster587/advancedRocketry/api/dimension/IDimensionProperties.java
@@ -185,7 +185,8 @@ public interface IDimensionProperties {
     /**
      * @return true if terraforming activity has changed the planet properties
      */
-    boolean isTerraformed();
+    // F*ck you
+    //boolean isTerraformed();
 
     /**
      * @return reource location of the planet

--- a/src/main/java/zmaster587/advancedRocketry/atmosphere/AtmosphereHandler.java
+++ b/src/main/java/zmaster587/advancedRocketry/atmosphere/AtmosphereHandler.java
@@ -1,5 +1,7 @@
 package zmaster587.advancedRocketry.atmosphere;
 
+import net.minecraft.block.BlockLeaves;
+import net.minecraft.block.BlockLiquid;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
@@ -93,6 +95,8 @@ public class AtmosphereHandler {
     //Called from setBlock in World.class
     public static void onBlockChange(@Nonnull World world, @Nonnull BlockPos bpos) {
 
+        // I am very sure all this shit here was NEVER tested!
+
         if (ARConfiguration.getCurrentConfig().enableOxygen && !world.isRemote && world.getChunkFromBlockCoords(new BlockPos(bpos)).isLoaded()) {
             HashedBlockPosition pos = new HashedBlockPosition(bpos);
 
@@ -129,10 +133,13 @@ public class AtmosphereHandler {
                     world.setBlockState(bpos, Blocks.FIRE.getDefaultState());
                 }
             }
-            //Plants should die
+
+
             else if (!handler.getAtmosphereType(bpos).allowsCombustion()) {
                 if (world.getBlockState(bpos).getBlock().isLeaves(world.getBlockState(bpos), world, bpos)) {
-                    world.setBlockToAir(bpos);
+                    if (!(Boolean)world.getBlockState(bpos).getValue(BlockLeaves.CHECK_DECAY)) {
+                        world.setBlockToAir(bpos);
+                    }
                 } else if (world.getBlockState(bpos).getMaterial() == Material.FIRE) {
                     world.setBlockToAir(bpos);
                 } else if (world.getBlockState(bpos).getMaterial() == Material.CACTUS) {
@@ -145,6 +152,7 @@ public class AtmosphereHandler {
                     world.setBlockState(bpos, Blocks.DIRT.getDefaultState());
                 }
             }
+
             //Gasses should automatically vaporize and dissipate
             if (handler.getAtmosphereType(bpos) == AtmosphereType.VACUUM) {
                 if (world.getBlockState(bpos).getMaterial() == Material.WATER && world.getBlockState(bpos).getBlock() instanceof IFluidBlock) {
@@ -154,9 +162,13 @@ public class AtmosphereHandler {
                 }
             }
             //Water blocks should also vaporize and disappear
-            /* yes but not like this because it crashes the game
+            /*
+            yes but not like this because it crashes the game
+            every updated water causes the water next to it to update -> stackoverflow -> server goes boom
+
+
             if (handler.getAtmosphereType(bpos) == AtmosphereType.SUPERHEATED || handler.getAtmosphereType(bpos) == AtmosphereType.SUPERHEATEDNOO2 || handler.getAtmosphereType(bpos) == AtmosphereType.VERYHOT || handler.getAtmosphereType(bpos) == AtmosphereType.VERYHOTNOO2) {
-                if (world.getBlockState(bpos).getMaterial() == Material.WATER) {
+                if (world.getBlockState(bpos).getMaterial() == Material.WATER && world.getBlockState(bpos).getValue(BlockLiquid.LEVEL) == 0) {
                     world.setBlockToAir(bpos);
                 }
             }

--- a/src/main/java/zmaster587/advancedRocketry/dimension/DimensionManager.java
+++ b/src/main/java/zmaster587/advancedRocketry/dimension/DimensionManager.java
@@ -325,7 +325,7 @@ public class DimensionManager implements IGalaxy {
 
         properties.rotationalPeriod = (int) (Math.pow((1 / properties.gravitationalMultiplier), 3) * 24000);
 
-        properties.addBiomes(properties.getViableBiomes());
+        properties.addBiomes(properties.getViableBiomes(true));
         properties.initDefaultAttributes();
 
         registerDim(properties, true);

--- a/src/main/java/zmaster587/advancedRocketry/dimension/DimensionProperties.java
+++ b/src/main/java/zmaster587/advancedRocketry/dimension/DimensionProperties.java
@@ -16,6 +16,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.Biome.TempCategory;
+import net.minecraft.world.biome.BiomeProvider;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.common.BiomeDictionary;
 import net.minecraftforge.common.BiomeManager;
@@ -154,6 +155,7 @@ public class DimensionProperties implements Cloneable, IDimensionProperties {
     boolean status_terraforming;
     public List<HashedBlockPosition> terraformingChangeList;
     public List<Chunk> terraformingChunkListCurrentCycle;
+    public BiomeProvider chunkMgrTerraformed;
 
     public List<watersourcelocked> water_source_locked_positions;
     //public boolean water_can_exist;
@@ -191,7 +193,7 @@ public class DimensionProperties implements Cloneable, IDimensionProperties {
         canGenerateCraters = true;
         canGenerateGeodes = true;
         canGenerateStructures = true;
-        canGenerateVolcanoes = true;
+        canGenerateVolcanoes = false;
         canGenerateCaves = true;
         hasRivers = true;
         craterFrequencyMultiplier = 1f;
@@ -214,6 +216,17 @@ public class DimensionProperties implements Cloneable, IDimensionProperties {
         water_source_locked_positions = new ArrayList<>();
 
         ringAngle = 70;
+
+
+        //dont need this here because the terraforming terminal will re-create it anyway
+        //this.chunkMgrTerraformed = new ChunkManagerPlanet(net.minecraftforge.common.DimensionManager.getWorld(id), net.minecraftforge.common.DimensionManager.getWorld(getId()).getWorldInfo().getGeneratorOptions(), getTerraformedBiomes());
+    }
+
+    public void reset_chunkmgr(){
+        World world = net.minecraftforge.common.DimensionManager.getWorld(getId());
+        getAverageTemp();
+        setTerraformedBiomes(DimensionManager.getInstance().getDimensionProperties(world.provider.getDimension()).getViableBiomes());
+        chunkMgrTerraformed = new ChunkManagerPlanet(world, world.getWorldInfo().getGeneratorOptions(), DimensionManager.getInstance().getDimensionProperties(world.provider.getDimension()).getTerraformedBiomes());
     }
 
     public void add_chunk_to_terraforming_list(Chunk chunk) {
@@ -708,8 +721,8 @@ public class DimensionProperties implements Cloneable, IDimensionProperties {
 
             setTerraformedBiomes(getViableBiomes());
 
-            WorldServer world = net.minecraftforge.common.DimensionManager.getWorld(getId());
-            ((WorldProviderPlanet) net.minecraftforge.common.DimensionManager.getProvider(getId())).chunkMgrTerraformed = new ChunkManagerPlanet(world, world.getWorldInfo().getGeneratorOptions(), DimensionManager.getInstance().getDimensionProperties(world.provider.getDimension()).getTerraformedBiomes());
+
+           reset_chunkmgr();
 
 
 
@@ -1051,9 +1064,6 @@ public class DimensionProperties implements Cloneable, IDimensionProperties {
      * @return true if the biome is not allowed to spawn on any Dimension
      */
     public boolean isBiomeblackListed(Biome biome) {
-        //use blacklist only when terraforming
-        if (!isTerraformed()) return false;
-
         return AdvancedRocketryBiomes.instance.getBlackListedBiomes().contains(Biome.getIdForBiome(biome));
     }
 

--- a/src/main/java/zmaster587/advancedRocketry/dimension/DimensionProperties.java
+++ b/src/main/java/zmaster587/advancedRocketry/dimension/DimensionProperties.java
@@ -266,8 +266,8 @@ public class DimensionProperties implements Cloneable, IDimensionProperties {
             System.out.println("List is 0 - this should never happen!!");
             return null; // this should never happen. Yes it would crash the game, but if it does, my code is wrong and needs to be fixed anyway
         }
-        //return terraformingChangeList.remove(nextInt(0,terraformingChangeList.size()));
-        return terraformingChangeList.remove(0);
+        return terraformingChangeList.remove(nextInt(0,terraformingChangeList.size()));
+        //return terraformingChangeList.remove(0);
     }
     public DimensionProperties(int id, String name) {
         this(id);

--- a/src/main/java/zmaster587/advancedRocketry/tile/satellite/TileTerraformingTerminal.java
+++ b/src/main/java/zmaster587/advancedRocketry/tile/satellite/TileTerraformingTerminal.java
@@ -150,11 +150,6 @@ public class TileTerraformingTerminal extends TileInventoriedRFConsumer implemen
             if (hasValidBiomeChanger() && has_redstone) {
                 if (!was_enabled_last_tick) {
                     was_enabled_last_tick = true;
-                    DimensionManager.getInstance().getDimensionProperties(world.provider.getDimension()).setIsTerraformed(true);
-
-                    //usually this should not need to be here because it is called at other places
-                    //just to be sure it is really called I do it again here
-                    DimensionManager.getInstance().getDimensionProperties(world.provider.getDimension()).reset_chunkmgr();
 
                     Item biomeChanger = getStackInSlot(0).getItem();
                     if (biomeChanger instanceof ItemBiomeChanger) {

--- a/src/main/java/zmaster587/advancedRocketry/util/XMLPlanetLoader.java
+++ b/src/main/java/zmaster587/advancedRocketry/util/XMLPlanetLoader.java
@@ -964,7 +964,7 @@ public class XMLPlanetLoader {
 
         //If no biomes are specified add some!
         if (properties.getBiomes().isEmpty())
-            properties.addBiomes(properties.getViableBiomes());
+            properties.addBiomes(properties.getViableBiomes(true));
 
         return list;
     }

--- a/src/main/java/zmaster587/advancedRocketry/world/ChunkManagerPlanet.java
+++ b/src/main/java/zmaster587/advancedRocketry/world/ChunkManagerPlanet.java
@@ -39,7 +39,7 @@ public class ChunkManagerPlanet extends BiomeProvider {
     private void setup(long seed, WorldType default1, String str, DimensionProperties properties){
         this.biomeCache = new BiomeCache(this);//new BiomeCacheExtended(this);
         //TODO: more biomes
-        //TODO: remove rivers
+        //TODO: remove rivers - why?
         GenLayer[] agenlayer = initializeAllBiomeGenerators(seed, default1, str, properties);//GenLayer.initializeAllBiomeGenerators(seed, default1); //;
         agenlayer = getModdedBiomeGenerators(default1, seed, agenlayer);
         this.genBiomes = agenlayer[0];

--- a/src/main/java/zmaster587/advancedRocketry/world/ChunkManagerPlanet.java
+++ b/src/main/java/zmaster587/advancedRocketry/world/ChunkManagerPlanet.java
@@ -12,6 +12,7 @@ import net.minecraft.world.biome.BiomeProvider;
 import net.minecraft.world.gen.ChunkGeneratorSettings;
 import net.minecraft.world.gen.layer.*;
 import net.minecraftforge.common.BiomeManager.BiomeEntry;
+import zmaster587.advancedRocketry.AdvancedRocketry;
 import zmaster587.advancedRocketry.dimension.DimensionManager;
 import zmaster587.advancedRocketry.dimension.DimensionProperties;
 
@@ -54,7 +55,7 @@ public class ChunkManagerPlanet extends BiomeProvider {
 
 
     public ChunkManagerPlanet(World world, String str, List<BiomeEntry> biomes) {
-        this(world.getSeed(), world.getWorldInfo().getTerrainType(), str, DimensionManager.getInstance().getDimensionProperties(world.provider.getDimension()));
+        this(world.getSeed(), AdvancedRocketry.planetWorldType, str, DimensionManager.getInstance().getDimensionProperties(world.provider.getDimension()));
         //Note: world MUST BE REGISTERED WITH THE DIMENSION MANAGER
         //This is a mess!
         this.biomes = biomes;

--- a/src/main/java/zmaster587/advancedRocketry/world/ChunkManagerPlanet.java
+++ b/src/main/java/zmaster587/advancedRocketry/world/ChunkManagerPlanet.java
@@ -1,7 +1,5 @@
 package zmaster587.advancedRocketry.world;
 
-import com.google.common.collect.Lists;
-import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import net.minecraft.crash.CrashReport;
 import net.minecraft.crash.CrashReportCategory;
 import net.minecraft.init.Biomes;
@@ -14,20 +12,14 @@ import net.minecraft.world.biome.BiomeProvider;
 import net.minecraft.world.gen.ChunkGeneratorSettings;
 import net.minecraft.world.gen.layer.*;
 import net.minecraftforge.common.BiomeManager.BiomeEntry;
-import net.minecraftforge.fml.relauncher.ReflectionHelper;
-import zmaster587.advancedRocketry.AdvancedRocketry;
 import zmaster587.advancedRocketry.dimension.DimensionManager;
 import zmaster587.advancedRocketry.dimension.DimensionProperties;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.lang.reflect.Field;
 import java.util.List;
 
 public class ChunkManagerPlanet extends BiomeProvider {
-    //TODO: make higher biome ids work
-    private static Field fBiomeCacheMap;
-    private static Field fBiomeCache;
     /**
      * A GenLayer containing the indices into BiomeGenBase.biomeList[]
      */
@@ -44,15 +36,6 @@ public class ChunkManagerPlanet extends BiomeProvider {
         agenlayer = getModdedBiomeGenerators(default1, seed, agenlayer);
         this.genBiomes = agenlayer[0];
         this.biomeIndexLayer = agenlayer[1];
-
-        ReflectionHelper.setPrivateValue(BiomeProvider.class, this, this.genBiomes, "genBiomes", "field_76944_d");
-        ReflectionHelper.setPrivateValue(BiomeProvider.class, this, this.biomeIndexLayer, "biomeIndexLayer", "field_76945_e");
-
-        fBiomeCache = ReflectionHelper.findField(BiomeCache.class, "cache", "field_76841_d");
-        fBiomeCache.setAccessible(true);
-
-        fBiomeCacheMap = ReflectionHelper.findField(BiomeCache.class, "cacheMap", "field_76843_c");
-        fBiomeCacheMap.setAccessible(true);
     }
 
     long seed;
@@ -71,7 +54,7 @@ public class ChunkManagerPlanet extends BiomeProvider {
 
 
     public ChunkManagerPlanet(World world, String str, List<BiomeEntry> biomes) {
-        this(world.getSeed(), AdvancedRocketry.planetWorldType, str, DimensionManager.getInstance().getDimensionProperties(world.provider.getDimension()));
+        this(world.getSeed(), world.getWorldInfo().getTerrainType(), str, DimensionManager.getInstance().getDimensionProperties(world.provider.getDimension()));
         //Note: world MUST BE REGISTERED WITH THE DIMENSION MANAGER
         //This is a mess!
         this.biomes = biomes;
@@ -190,16 +173,6 @@ public class ChunkManagerPlanet extends BiomeProvider {
     }
 
 
-    public void resetCache() {
-
-        try {
-            fBiomeCacheMap.set(this.biomeCache, new Long2ObjectOpenHashMap(4096));
-            fBiomeCache.set(this.biomeCache, Lists.newArrayList());
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-
-    }
 
     @Nonnull
     public Biome[] getBiomesForGeneration(@Nullable Biome[] biomes, int x, int z, int width, int height) {

--- a/src/main/java/zmaster587/advancedRocketry/world/provider/WorldProviderPlanet.java
+++ b/src/main/java/zmaster587/advancedRocketry/world/provider/WorldProviderPlanet.java
@@ -44,7 +44,7 @@ import javax.annotation.Nullable;
 import java.util.Set;
 
 public class WorldProviderPlanet extends WorldProvider implements IPlanetaryProvider {
-    public BiomeProvider chunkMgrTerraformed;
+
 
 	/*@Override
 	protected void registerWorldChunkManager() {
@@ -103,7 +103,6 @@ public class WorldProviderPlanet extends WorldProvider implements IPlanetaryProv
 
 
         this.biomeProvider = new ChunkManagerPlanet(world, world.getWorldInfo().getGeneratorOptions(), DimensionManager.getInstance().getDimensionProperties(world.provider.getDimension()).getBiomes());
-        this.chunkMgrTerraformed = new ChunkManagerPlanet(world, world.getWorldInfo().getGeneratorOptions(), DimensionManager.getInstance().getDimensionProperties(world.provider.getDimension()).getTerraformedBiomes());
         //AdvancedRocketry.planetWorldType.getChunkManager(worldObj);
     }
 


### PR DESCRIPTION
by moving the biome provider from the WorldProviderPlanet to the Dimensionproperties it can be used on dimensions that do not use the WorldProviderPlanet.

The way the biomeprovider is initialized now might be a bit ugly ( in terraformingTerminal )

+Bugfix for leaf decay:
Leaves do a blockchange when destroyed before they remove themself and this caused a stackoverflow in atmospherehandler.
 The atmospherehandler is still bugged and incomplete